### PR TITLE
Refactor to share option analysis logic

### DIFF
--- a/option_analyzer_v5.py
+++ b/option_analyzer_v5.py
@@ -1,161 +1,17 @@
-import yfinance as yf
-import pandas as pd
-from datetime import datetime
-import numpy as np
-import time
+from option_analyzers import OptionChainAnalyzer
 
-def get_current_price(ticker):
-    """Get current stock price with retries"""
-    max_retries = 3
-    for attempt in range(max_retries):
-        try:
-            stock = yf.Ticker(ticker)
-            price = stock.history(period='1d')['Close'].iloc[-1]
-            if price:
-                return price
-        except Exception as e:
-            if attempt < max_retries - 1:
-                print(f"Retry {attempt + 1} of {max_retries} for price fetch...")
-                time.sleep(1)
-            else:
-                raise Exception(f"Could not fetch price after {max_retries} attempts: {str(e)}")
-    return None
 
-def analyze_option_chain(ticker_symbol="ORCL", min_volume=50, max_expirations=2, 
-                        min_annual_tv_pct=9.9, max_otm_pct=5.0):
-    """
-    Analyze option chain for a given stock ticker and find best time value opportunities
-    for near-the-money call options.
-    
-    Args:
-        ticker_symbol (str): Stock symbol
-        min_volume (int): Minimum option volume
-        max_expirations (int): Number of expiration dates to analyze
-        min_annual_tv_pct (float): Minimum annualized time value percentage
-        max_otm_pct (float): Maximum percentage out-of-the-money to consider
-    """
-    print(f"\nFetching data for {ticker_symbol}...")
-    print(f"Filtering for options with:")
-    print(f"- Minimum annualized time value: {min_annual_tv_pct}%")
-    print(f"- Maximum OTM percentage: {max_otm_pct}%")
-    print(f"- Minimum volume: {min_volume}")
-    
-    try:
-        # Get current stock price using simplified method
-        current_price = get_current_price(ticker_symbol)
-        if not current_price:
-            print(f"Error: Could not fetch current price for {ticker_symbol}")
-            return
-        
-        print(f"\nCurrent Price: ${current_price:.2f}")
-        
-        # Calculate price range for near-the-money options
-        max_strike = current_price * (1 + max_otm_pct/100)
-        min_strike = current_price * 0.99  # Consider options just slightly ITM
-        
-        print(f"Analyzing strikes between ${min_strike:.2f} and ${max_strike:.2f}")
-        
-        # Get stock object
-        stock = yf.Ticker(ticker_symbol)
-        
-        # Get expiration dates
-        all_expirations = stock.options
-        if not all_expirations:
-            print("No options data available")
-            return
-            
-        expirations = all_expirations[:max_expirations]
-        print(f"Analyzing {len(expirations)} expiration dates")
-        
-        results = []
-        
-        # Analyze each expiration date
-        for expiry in expirations:
-            print(f"\nProcessing {expiry}...")
-            
-            # Get option chain
-            opt = stock.option_chain(expiry)
-            calls = opt.calls
-            
-            # Filter for near-the-money calls
-            ntm_calls = calls[
-                (calls['strike'] >= min_strike) & 
-                (calls['strike'] <= max_strike)
-            ]
-            
-            # Filter for minimum volume
-            ntm_calls = ntm_calls[ntm_calls['volume'] >= min_volume]
-            
-            if len(ntm_calls) == 0:
-                print(f"No suitable options found for {expiry}")
-                continue
-            
-            # Calculate metrics for each option
-            for _, option in ntm_calls.iterrows():
-                days_to_expiry = (pd.to_datetime(expiry) - pd.to_datetime(datetime.now().date())).days
-                
-                if days_to_expiry <= 0:
-                    continue
-                
-                # Calculate time value
-                if option['strike'] > current_price:
-                    # OTM option - all premium is time value
-                    time_value = option['lastPrice']
-                else:
-                    # ITM option - subtract intrinsic value
-                    intrinsic = max(0, current_price - option['strike'])
-                    time_value = option['lastPrice'] - intrinsic
-                
-                # Calculate annualized time value percentage
-                time_value_pct = (time_value / option['strike']) * (365 / days_to_expiry) * 100
-                
-                # Only include if meets minimum time value percentage
-                if time_value_pct >= min_annual_tv_pct:
-                    results.append({
-                        'Expiration': expiry,
-                        'Strike': option['strike'],
-                        'Last': option['lastPrice'],
-                        'Bid': option['bid'],
-                        'Ask': option['ask'],
-                        'Volume': option['volume'],
-                        'OI': option['openInterest'],
-                        'TimeVal$': time_value,
-                        'Days': days_to_expiry,
-                        'Ann.TV%': time_value_pct,
-                        'Dist.%': ((option['strike'] - current_price) / current_price) * 100
-                    })
-        
-        if not results:
-            print("\nNo options found matching the criteria:")
-            print(f"- Annualized time value >= {min_annual_tv_pct}%")
-            print(f"- Within {max_otm_pct}% of current price")
-            print(f"- Volume >= {min_volume}")
-            return
-        
-        # Convert results to DataFrame and sort
-        df_results = pd.DataFrame(results)
-        df_results = df_results.sort_values('Ann.TV%', ascending=False)
-        
-        # Print results
-        print("\nBest Time Value Opportunities (sorted by annualized time value):")
-        print("=========================================================")
-        pd.set_option('display.float_format', lambda x: '%.2f' % x)
-        pd.set_option('display.max_columns', None)
-        pd.set_option('display.width', None)
-        print(df_results.to_string(index=False))
-        
-        return df_results
-        
-    except Exception as e:
-        print(f"Error in analysis: {str(e)}")
-        return None
+def main():
+    analyzer = OptionChainAnalyzer()
+    analyzer.analyze(
+        ticker_symbol="ORCL",
+        min_volume=50,
+        max_expirations=2,
+        min_annual_tv_pct=9.9,
+        max_otm_pct=5.0,
+    )
+
 
 if __name__ == "__main__":
-    # Example usage
-    analyze_option_chain(
-        ticker_symbol="ORCL",
-        min_volume=50,           # Minimum trading volume
-        max_expirations=2,       # Look at nearest 2 expiration dates
-        min_annual_tv_pct=9.9,   # Minimum annualized time value percentage
-        max_otm_pct=5.0          # Maximum percentage out-of-the-money
-    )
+    main()
+

--- a/option_analyzers.py
+++ b/option_analyzers.py
@@ -1,0 +1,180 @@
+import time
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List, Optional
+
+import pandas as pd
+import yfinance as yf
+
+
+class BaseOptionAnalyzer(ABC):
+    """Shared utilities for option analysis."""
+
+    def get_current_price(self, ticker: str, max_retries: int = 3) -> float:
+        """Fetch the current stock price with retries."""
+        for attempt in range(max_retries):
+            try:
+                stock = yf.Ticker(ticker)
+                price = stock.history(period="1d")["Close"].iloc[-1]
+                if price:
+                    return price
+            except Exception:
+                if attempt < max_retries - 1:
+                    time.sleep(1 + attempt)
+                else:
+                    raise
+        raise RuntimeError(f"Failed to fetch price for {ticker}")
+
+    @abstractmethod
+    def analyze(self, *args, **kwargs):
+        """Run the option analysis and return a DataFrame."""
+        raise NotImplementedError
+
+
+class OptionChainAnalyzer(BaseOptionAnalyzer):
+    """Find near-the-money call options with high time value."""
+
+    def analyze(
+        self,
+        ticker_symbol: str,
+        min_volume: int = 50,
+        max_expirations: int = 2,
+        min_annual_tv_pct: float = 9.9,
+        max_otm_pct: float = 5.0,
+    ) -> Optional[pd.DataFrame]:
+        print(f"\nFetching data for {ticker_symbol}...")
+        print(f"Filtering for options with:")
+        print(f"- Minimum annualized time value: {min_annual_tv_pct}%")
+        print(f"- Maximum OTM percentage: {max_otm_pct}%")
+        print(f"- Minimum volume: {min_volume}")
+
+        current_price = self.get_current_price(ticker_symbol)
+        print(f"\nCurrent Price: ${current_price:.2f}")
+
+        max_strike = current_price * (1 + max_otm_pct / 100)
+        min_strike = current_price * 0.99
+        print(f"Analyzing strikes between ${min_strike:.2f} and ${max_strike:.2f}")
+
+        stock = yf.Ticker(ticker_symbol)
+        all_expirations = stock.options
+        if not all_expirations:
+            print("No options data available")
+            return None
+        expirations = all_expirations[:max_expirations]
+        print(f"Analyzing {len(expirations)} expiration dates")
+
+        results = []
+        for expiry in expirations:
+            print(f"\nProcessing {expiry}...")
+            calls = stock.option_chain(expiry).calls
+            ntm_calls = calls[(calls["strike"] >= min_strike) & (calls["strike"] <= max_strike)]
+            ntm_calls = ntm_calls[ntm_calls["volume"] >= min_volume]
+            if ntm_calls.empty:
+                print(f"No suitable options found for {expiry}")
+                continue
+            for _, option in ntm_calls.iterrows():
+                days_to_expiry = (
+                    pd.to_datetime(expiry) - pd.to_datetime(datetime.now().date())
+                ).days
+                if days_to_expiry <= 0:
+                    continue
+                if option["strike"] > current_price:
+                    time_value = option["lastPrice"]
+                else:
+                    intrinsic = max(0, current_price - option["strike"])
+                    time_value = option["lastPrice"] - intrinsic
+                time_value_pct = (
+                    time_value / option["strike"] * (365 / days_to_expiry) * 100
+                )
+                if time_value_pct >= min_annual_tv_pct:
+                    results.append(
+                        {
+                            "Expiration": expiry,
+                            "Strike": option["strike"],
+                            "Last": option["lastPrice"],
+                            "Bid": option["bid"],
+                            "Ask": option["ask"],
+                            "Volume": option["volume"],
+                            "OI": option["openInterest"],
+                            "TimeVal$": time_value,
+                            "Days": days_to_expiry,
+                            "Ann.TV%": time_value_pct,
+                            "Dist.%": ((option["strike"] - current_price) / current_price)
+                            * 100,
+                        }
+                    )
+        if not results:
+            print("\nNo options found matching the criteria")
+            return None
+        df_results = pd.DataFrame(results).sort_values("Ann.TV%", ascending=False)
+        print("\nBest Time Value Opportunities (sorted by annualized time value):")
+        print("=========================================================")
+        pd.set_option("display.float_format", lambda x: "%.2f" % x)
+        pd.set_option("display.max_columns", None)
+        pd.set_option("display.width", None)
+        print(df_results.to_string(index=False))
+        return df_results
+
+
+class TimeValueAnalyzer(BaseOptionAnalyzer):
+    """Analyze multiple tickers for out-of-the-money call time value."""
+
+    def analyze(
+        self, tickers: Optional[List[str]] = None, min_time_value: float = 0.10
+    ) -> Optional[pd.DataFrame]:
+        tickers = tickers or ["ORCL", "AMZN", "XOM"]
+        all_opportunities = []
+        for ticker in tickers:
+            print(f"\nAnalyzing {ticker}...")
+            stock = yf.Ticker(ticker)
+            current_price = stock.info.get("regularMarketPrice")
+            dates = stock.options[:3]
+            all_calls = []
+            for date in dates:
+                try:
+                    calls = stock.option_chain(date).calls
+                    calls["expirationDate"] = date
+                    calls["stockPrice"] = current_price
+                    all_calls.append(calls)
+                    time.sleep(1)
+                except Exception as e:
+                    print(f"Error getting option chain for {ticker} {date}: {e}")
+            if not all_calls:
+                continue
+            chain = pd.concat(all_calls)
+            otm_calls = chain[chain["strike"] > current_price].copy()
+            if otm_calls.empty:
+                continue
+            otm_calls["timeValue"] = otm_calls.apply(
+                lambda r: r["lastPrice"] - max(0, r["stockPrice"] - r["strike"]),
+                axis=1,
+            )
+            good = otm_calls[otm_calls["timeValue"] >= min_time_value].copy()
+            if not good.empty:
+                good["ticker"] = ticker
+                good["percentOTM"] = (
+                    (good["strike"] - current_price) / current_price * 100
+                )
+                all_opportunities.append(good)
+        if not all_opportunities:
+            print("No opportunities found matching criteria")
+            return None
+        all_df = pd.concat(all_opportunities)
+        result = all_df[
+            [
+                "ticker",
+                "expirationDate",
+                "strike",
+                "lastPrice",
+                "timeValue",
+                "percentOTM",
+                "volume",
+                "openInterest",
+            ]
+        ].copy()
+        result = result.sort_values("timeValue", ascending=False)
+        result["percentOTM"] = result["percentOTM"].round(2)
+        result["timeValue"] = result["timeValue"].round(2)
+        result["strike"] = result["strike"].round(2)
+        result["lastPrice"] = result["lastPrice"].round(2)
+        return result

--- a/option_time_value.py
+++ b/option_time_value.py
@@ -1,139 +1,35 @@
-import yfinance as yf
 import pandas as pd
-from datetime import datetime
-import time
+from option_analyzers import TimeValueAnalyzer
 
-def get_option_chain(ticker):
-    """
-    Get option chain for a ticker with rate limit handling
-    """
-    try:
-        stock = yf.Ticker(ticker)
-        time.sleep(1)  # Rate limit handling
-        
-        # Get current stock price
-        current_price = stock.info['regularMarketPrice']
-        
-        # Get all expiration dates
-        dates = stock.options
-        
-        if not dates:
-            return None, None, None
-            
-        # We'll look at the first 3 expiration dates to limit API calls
-        dates = dates[:3]
-        
-        all_calls = []
-        for date in dates:
-            try:
-                opt = stock.option_chain(date)
-                calls = opt.calls
-                calls['expirationDate'] = date
-                calls['stockPrice'] = current_price
-                all_calls.append(calls)
-                time.sleep(1)  # Rate limit handling
-            except Exception as e:
-                print(f"Error getting option chain for {ticker} date {date}: {e}")
-                continue
-                
-        if not all_calls:
-            return None, None, None
-            
-        return pd.concat(all_calls), current_price, ticker
-    except Exception as e:
-        print(f"Error processing {ticker}: {e}")
-        return None, None, None
-
-def calculate_time_value(row):
-    """
-    Calculate time value for an option
-    Time Value = Option Price - (Stock Price - Strike Price)
-    """
-    intrinsic_value = max(0, row['stockPrice'] - row['strike'])
-    time_value = row['lastPrice'] - intrinsic_value
-    return time_value
-
-def analyze_options(tickers=["ORCL", "AMZN", "XOM"], min_time_value=0.10):
-    """
-    Analyze options for multiple tickers and find best time value opportunities
-    """
-    all_opportunities = []
-    
-    for ticker in tickers:
-        print(f"\nAnalyzing {ticker}...")
-        option_chain, current_price, ticker_name = get_option_chain(ticker)
-        
-        if option_chain is None:
-            continue
-            
-        # Filter for OTM calls
-        otm_calls = option_chain[option_chain['strike'] > current_price].copy()
-        
-        if len(otm_calls) == 0:
-            continue
-            
-        # Calculate time value
-        otm_calls['timeValue'] = otm_calls.apply(calculate_time_value, axis=1)
-        
-        # Filter by minimum time value
-        good_opportunities = otm_calls[otm_calls['timeValue'] >= min_time_value].copy()
-        
-        if len(good_opportunities) > 0:
-            good_opportunities['ticker'] = ticker_name
-            good_opportunities['percentOTM'] = ((good_opportunities['strike'] - current_price) / current_price) * 100
-            all_opportunities.append(good_opportunities)
-    
-    if not all_opportunities:
-        print("No opportunities found matching criteria")
-        return None
-        
-    # Combine all opportunities
-    all_df = pd.concat(all_opportunities)
-    
-    # Select and rename relevant columns
-    result = all_df[[
-        'ticker', 'expirationDate', 'strike', 'lastPrice', 'timeValue', 
-        'percentOTM', 'volume', 'openInterest'
-    ]].copy()
-    
-    # Sort by time value descending
-    result = result.sort_values('timeValue', ascending=False)
-    
-    # Format the results
-    result['percentOTM'] = result['percentOTM'].round(2)
-    result['timeValue'] = result['timeValue'].round(2)
-    result['strike'] = result['strike'].round(2)
-    result['lastPrice'] = result['lastPrice'].round(2)
-    
-    return result
 
 def main():
-    # Get user input for tickers
     default_tickers = ["ORCL", "AMZN", "XOM"]
-    user_input = input(f"Enter stock tickers separated by comma (default: {','.join(default_tickers)}): ").strip()
-    
-    if user_input:
-        tickers = [ticker.strip().upper() for ticker in user_input.split(',')]
-    else:
-        tickers = default_tickers
-    
-    # Get minimum time value
+    user_input = input(
+        f"Enter stock tickers separated by comma (default: {','.join(default_tickers)}): "
+    ).strip()
+    tickers = (
+        [t.strip().upper() for t in user_input.split(',')] if user_input else default_tickers
+    )
+
     while True:
         try:
             min_time_value = float(input("Enter minimum time value (default: 0.10): ") or 0.10)
             break
         except ValueError:
             print("Please enter a valid number")
-    
+
+    analyzer = TimeValueAnalyzer()
     print("\nAnalyzing options... This may take a moment.")
-    results = analyze_options(tickers, min_time_value)
-    
+    results = analyzer.analyze(tickers=tickers, min_time_value=min_time_value)
+
     if results is not None:
         pd.set_option('display.max_rows', None)
         pd.set_option('display.max_columns', None)
         pd.set_option('display.width', None)
         print("\nTop Time Value Opportunities:")
         print(results)
-    
+
+
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- Create `option_analyzers` module with a `BaseOptionAnalyzer` and two concrete analyzers
- Rewrite `option_analyzer_v5` to use new `OptionChainAnalyzer`
- Simplify `option_time_value` to use shared `TimeValueAnalyzer`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68977d77f368832f8401d283c1c62c40